### PR TITLE
Declare terminus 2 compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   },
   "extra": {
     "terminus": {
-      "compatible-version": "^1"
+      "compatible-version": "^2"
     }
   }
 }


### PR DESCRIPTION
Adding terminus 2 compatibility indirectly adds terminus 3 compatibility. I didn't explicitly declared t3 compatibility because I haven't really tested it (besides ensuring it doesn't break)